### PR TITLE
fix: GO-2026-5856 対応で Go toolchain を 1.26.5 に更新

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/youyo/tfstore
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.0


### PR DESCRIPTION
## 概要

GO-2026-5856 に対応するため、`go.mod` の toolchain バージョンを `go1.26.4` から `go1.26.5` に更新します。

## 変更内容

- `toolchain go1.26.4` → `toolchain go1.26.5`

## 検証

- build / vet / test すべて green
- ローカル govulncheck クリーン

## 補足

本 PR がマージされると、既存の Dependabot PR 4件についても govulncheck が green になる見込みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)